### PR TITLE
depend on quiver explicitly

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,4 +15,5 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  quiver: '>=0.24.0 <2.0.0'
   test: any


### PR DESCRIPTION
`pub publish` alerted me to a missing dependency on quiver. We get it transitively via `flutter_test`, but transitive deps are discouraged.