### PR TITLE
allow using double for exponentialBackoffMultiplier

### DIFF
--- a/lib/network.dart
+++ b/lib/network.dart
@@ -379,7 +379,7 @@ class FetchStrategyBuilder {
 
   /// The pause between retries is multiplied by this number with each attempt,
   /// causing it to grow exponentially.
-  final int exponentialBackoffMultiplier;
+  final num exponentialBackoffMultiplier;
 
   /// A function that determines whether a given HTTP status code should be
   /// retried.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12305

/cc @apwilson 