### PR TITLE
Fix `FetchInstructions` assertion

### DIFF
--- a/lib/network.dart
+++ b/lib/network.dart
@@ -97,7 +97,7 @@ class NetworkImageWithRetry extends ImageProvider<NetworkImageWithRetry> {
         }
       }
       return true;
-    });
+    }());
   }
 
   Future<ImageInfo> _loadWithRetry(NetworkImageWithRetry key) async {


### PR DESCRIPTION
The check function is being asserted rather than it's return value.