### PR TITLE
Update package version and bump to dart2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - fonts-droid
 
 before_script:
-  - git clone https://github.com/flutter/flutter.git -b alpha --depth 1
+  - git clone https://github.com/flutter/flutter.git -b beta --depth 1
   - export PATH=$PATH:$(pwd)/flutter/bin
   - export FLUTTER_HOME=$(pwd)/flutter
   - flutter doctor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+* **Breaking change**. SDK constraints to support Flutter beta versions and Dart 2 only.
+
 ## 0.0.3
 
 - Moved `flutter_test` to dev_dependencies in `pubspec.yaml`, and fixed issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,13 @@
 name: flutter_image
-version: 0.0.3
+version: 1.0.0
 description: >
   Image utilities for Flutter: providers, effects, etc
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/flutter_image
 
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,10 +5,6 @@ description: >
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/flutter_image
 
-environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
-
 dependencies:
   flutter:
     sdk: flutter
@@ -18,3 +14,7 @@ dev_dependencies:
   test: any
   flutter_test:
     sdk: flutter
+
+environment:
+  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"


### PR DESCRIPTION
Make a Dart 2 / Flutter beta only v1.0.0.
Make sure version is bumped after https://github.com/flutter/flutter_image/pull/9.

Fixes https://github.com/flutter/flutter/issues/15772